### PR TITLE
Implement tunnel using frp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 .nimbus
 .vms
 __pycache__
+*.pem
+*.yml
+*.exe
+frp_0.59.0_windows_amd64

--- a/Server.py
+++ b/Server.py
@@ -4,19 +4,50 @@ from pydantic import BaseModel
 import subprocess
 import os
 from shutil import rmtree
-from typing import List, Literal
-import threading
+from typing import List, Literal, Set
 import time
 import json
+from pathlib import Path
+import psutil
+from contextlib import asynccontextmanager
 
+# --- Configuration ---
+BASE_DIR = Path(__file__).parent
+VMS_DIR = BASE_DIR / ".vms"
+SSH_DIR = BASE_DIR / ".ssh"
+REGISTRY_FILE = VMS_DIR / "registry.json"
 
-app = FastAPI()
+# --- FRP Configuration ---
+FRP_DIR = BASE_DIR / "frp_0.59.0_windows_amd64"  # Adjust this path as needed
+FRP_EXECUTABLE_PATH = FRP_DIR / "frpc.exe" # Or "frpc" on Linux/macOS
+FRP_CONFIG_PATH = FRP_DIR / "frpc.toml"
+frpc_process = None # Global variable to hold the frpc process
 
+# --- Lifespan Manager (Replaces deprecated on_event) ---
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Code to run on startup
+    if not FRP_CONFIG_PATH.exists():
+        raise FileNotFoundError(f"CRITICAL: {FRP_CONFIG_PATH} not found.")
+    if not FRP_EXECUTABLE_PATH.exists():
+        raise FileNotFoundError(f"CRITICAL: frpc executable not found at {FRP_EXECUTABLE_PATH}")
+    start_frpc()
+    
+    yield # The application runs
+    
+    # Code to run on shutdown
+    print("Shutting down server...")
+    stop_frpc()
+
+app = FastAPI(
+    title="Nimbus-IaaS Controller",
+    description="An API to manage local VMs and their frp tunnels.",
+    lifespan=lifespan
+)
 
 class InboundRule(BaseModel):
     type: Literal["http", "tcp"]
     vm_port: int
-    localhost_port: int
 
 class VirtualMachine(BaseModel):
     username: str
@@ -25,8 +56,6 @@ class VirtualMachine(BaseModel):
     cpu: int
     image: str
     inbound_rules: List[InboundRule]
-    private_ip: str
-    
 
 ############################################################ SSH Key Generation and Download Endpoints ############################################################
 @app.post("/generate-key/{key_name}")
@@ -35,322 +64,296 @@ async def generate_key(key_name: str):
         if not key_name.isalnum() or " " in key_name:
             raise HTTPException(status_code=400, detail="Key name must be alphanumeric and contain no spaces.")
 
-        public_key_path = f".ssh/{key_name}.pub"
-        private_key_path = f".ssh/{key_name}"
+        SSH_DIR.mkdir(exist_ok=True)
+        private_key_path = SSH_DIR / key_name
 
-        if os.path.exists(public_key_path):
+        if private_key_path.exists():
             raise HTTPException(status_code=400, detail=f"Key '{key_name}' already exists.")
 
-        os.makedirs(".ssh", exist_ok=True)
+        command = ["ssh-keygen", "-t", "rsa", "-b", "2048", "-f", str(private_key_path), "-N", "", "-C", key_name]
 
-        command = ["ssh-keygen", "-t", "rsa", "-b", "2048", "-f", private_key_path, "-N", "", "-C", key_name]
-
-        process = subprocess.run(
-            command,
-            check=True,
-            capture_output=True,
-            text=True
-        )
-
-        os.chmod(private_key_path, 0o600)
+        subprocess.run(command, check=True, capture_output=True, text=True)
+        private_key_path.chmod(0o600)
 
         return {"message": f"SSH key '{key_name}' generated successfully.", "download_path": f"/download/{key_name}"}
-
     except subprocess.CalledProcessError as e:
         raise HTTPException(status_code=500, detail=f"SSH keygen failed: {e.stderr.strip()}")
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-
 @app.get("/download/{key_name}")
 async def download_key(key_name: str):
-    public_key_path = f".ssh/{key_name}.pub"
-    private_key_path = f".ssh/{key_name}"
-
-    if not os.path.exists(public_key_path) or not os.path.exists(private_key_path):
+    private_key_path = SSH_DIR / key_name
+    if not private_key_path.exists():
         raise HTTPException(status_code=404, detail=f"Key '{key_name}' does not exist.")
-
-    return FileResponse(
-        path=private_key_path,
-        filename=key_name,
-        media_type='application/octet-stream'
-    )
-
+    return FileResponse(path=private_key_path, filename=key_name, media_type='application/octet-stream')
 
 #######################################################################################################################################################################
 
-
-
-
-
-
 ############################################################# VM Registry Management ###########################################################################
-
-   
-
 def get_vagrantfile_content(vm: VirtualMachine, private_ip) -> str:
+    pub_key_path = SSH_DIR / f"{vm.key_name}.pub"
+    if not pub_key_path.exists():
+        raise FileNotFoundError(f"Public key file not found: {pub_key_path}")
+
+    # Escape backslashes for Vagrant's Ruby parser
+    pub_key_path_str = str(pub_key_path).replace("\\", "/")
+
     return f"""
-    Vagrant.configure("2") do |config|
-        # --- Ruby variables ---
-        NEW_USERNAME = "{vm.username}"
-        NEW_HOSTNAME = "{vm.username}"
-
-        config.vm.box = "{vm.image}"
-        config.vm.network "private_network", ip: "{private_ip}"
-
-        # Set the hostname
-        config.vm.hostname = NEW_HOSTNAME
-        config.hostsupdater.aliases = [NEW_HOSTNAME]
-
-        config.vm.provider "virtualbox" do |vb|
-            vb.memory = "{vm.ram}"
-            vb.cpus = "{vm.cpu}"
-        end
-
-        config.ssh.insert_key = false
-
-        # Copy SSH public key to the guest
-        config.vm.provision "file", source: "../../.ssh/{vm.key_name}.pub", destination: "/tmp/user_public_key.pub"
-
-        # Provision VM using shell
-        config.vm.provision "shell", inline: <<-SHELL
-            NEW_USERNAME="{vm.username}"
-
-            echo "Provisioning VM with user '$NEW_USERNAME'..."
-
-            # Create user with home and bash shell
-            useradd --create-home --shell /bin/bash "$NEW_USERNAME"
-            usermod -aG wheel "$NEW_USERNAME"
-
-            # Allow passwordless sudo for the new user
-            echo "$NEW_USERNAME ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$NEW_USERNAME
-            chmod 440 /etc/sudoers.d/$NEW_USERNAME
-
-            # Setup SSH key for the new user
-            mkdir -p /home/$NEW_USERNAME/.ssh
-            cat /tmp/user_public_key.pub > /home/$NEW_USERNAME/.ssh/authorized_keys
-            chown -R $NEW_USERNAME:$NEW_USERNAME /home/$NEW_USERNAME/.ssh
-            chmod 700 /home/$NEW_USERNAME/.ssh
-            chmod 600 /home/$NEW_USERNAME/.ssh/authorized_keys
-
-            # Ensure SSHD allows public key auth
-            sed -i 's/^PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config || true
-            systemctl restart sshd || systemctl restart ssh
-
-            echo "Provisioning complete. You can SSH using:"
-            echo "ssh -i ~/.ssh/{vm.key_name} {vm.username}@{private_ip}"
-        SHELL
+Vagrant.configure("2") do |config|
+    NEW_USERNAME = "{vm.username}"
+    NEW_HOSTNAME = "{vm.username}"
+    config.vm.box = "{vm.image}"
+    config.vm.network "private_network", ip: "{private_ip}"
+    config.vm.hostname = NEW_HOSTNAME
+    config.hostsupdater.aliases = [NEW_HOSTNAME]
+    config.vm.provider "virtualbox" do |vb|
+        vb.memory = "{vm.ram}"
+        vb.cpus = "{vm.cpu}"
     end
-    """
-    
+    config.ssh.insert_key = false
+    config.vm.provision "file", source: "{pub_key_path_str}", destination: "/tmp/user_public_key.pub"
+    config.vm.provision "shell", inline: <<-SHELL
+        NEW_USERNAME="{vm.username}"
+        echo "Provisioning VM with user '$NEW_USERNAME'..."
+        useradd --create-home --shell /bin/bash "$NEW_USERNAME"
+        usermod -aG wheel "$NEW_USERNAME"
+        echo "$NEW_USERNAME ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$NEW_USERNAME
+        chmod 440 /etc/sudoers.d/$NEW_USERNAME
+        mkdir -p /home/$NEW_USERNAME/.ssh
+        cat /tmp/user_public_key.pub > /home/$NEW_USERNAME/.ssh/authorized_keys
+        chown -R $NEW_USERNAME:$NEW_USERNAME /home/$NEW_USERNAME/.ssh
+        chmod 700 /home/$NEW_USERNAME/.ssh
+        chmod 600 /home/$NEW_USERNAME/.ssh/authorized_keys
+        sed -i 's/^PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config || true
+        systemctl restart sshd || systemctl restart ssh
+        echo "Provisioning complete."
+    SHELL
+end
+"""
 
-REGISTRY_FILE = ".vms/registry.json"
 
 def load_vm_registry():
-    if not os.path.exists(REGISTRY_FILE):
+    if not REGISTRY_FILE.exists():
         return {}
     with open(REGISTRY_FILE, "r") as f:
         return json.load(f)
 
 def save_vm_registry(registry):
+    VMS_DIR.mkdir(exist_ok=True)
     with open(REGISTRY_FILE, "w") as f:
         json.dump(registry, f, indent=4)
-        
+
 def stream_vagrant_up(vm_path: str):
     try:
-        process = subprocess.Popen(
-            ["vagrant", "up"],
-            cwd=vm_path,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            bufsize=1,
-            text=True
-        )
-
+        process = subprocess.Popen(["vagrant", "up"], cwd=vm_path, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
         for line in process.stdout:
             print(f"[VAGRANT]: {line}", end="")
-
         process.wait()
         print(f"[INFO] Vagrant exited with code: {process.returncode}")
-
     except Exception as e:
         print(f"[ERROR] Exception during Vagrant up: {e}")
 
-
-def find_ip(registry_path=".vms/registry.json", base_ip="192.168.56.", start=11, end=250):
-    used_ips = set()
-
-    if os.path.exists(registry_path):
-        with open(registry_path, "r") as f:
-            data = json.load(f)
-            for vm_info in data.values():
-                ip = vm_info.get("private_ip")
-                if ip:
-                    used_ips.add(ip)
-
+def find_ip(base_ip="192.168.56.", start=11, end=250):
+    registry = load_vm_registry()
+    used_ips = {vm.get("private_ip") for vm in registry.values()}
     for i in range(start, end):
         candidate = f"{base_ip}{i}"
         if candidate not in used_ips:
             return candidate
-
     raise Exception("No available IP addresses in range.")
+
+## FIXED ## --- Function to find available remote port for frp ---
+def find_available_remotePort(exclude_ports: Set[int] = None, start=2222, end=3000):
+    if exclude_ports is None:
+        exclude_ports = set()
+    
+    registry = load_vm_registry()
+    used_ports = set()
+    for vm in registry.values():
+        for rule in vm.get("inbound_rules", []):
+            if "" in rule:
+                used_ports.add(rule["remotePort"])
+    
+    # Combine saved ports with ports assigned in the current request
+    all_used_ports = used_ports.union(exclude_ports)
+
+    for port in range(start, end):
+        if port not in all_used_ports:
+            return port
+    raise Exception("No available remote ports for tunnels.")
+
+## --- FRPC Process Management Functions ---
+def start_frpc():
+    global frpc_process
+    if frpc_process and psutil.pid_exists(frpc_process.pid):
+        print("frpc is already running.")
+        return
+    print(f"Starting frpc with config: {FRP_CONFIG_PATH}")
+    frpc_process = subprocess.Popen([str(FRP_EXECUTABLE_PATH), "-c", str(FRP_CONFIG_PATH)])
+    print(f"frpc started successfully with PID: {frpc_process.pid}")
+
+def stop_frpc():
+    global frpc_process
+    if not frpc_process or not psutil.pid_exists(frpc_process.pid):
+        print("frpc is not running or PID not found.")
+        return
+    print(f"Stopping frpc process with PID: {frpc_process.pid}")
+    try:
+        p = psutil.Process(frpc_process.pid)
+        p.terminate()
+        p.wait(timeout=5)
+    except psutil.NoSuchProcess:
+        pass
+    except psutil.TimeoutExpired:
+        print("frpc did not terminate gracefully, killing it.")
+        p.kill()
+    print("frpc stopped.")
+    frpc_process = None
+
+def restart_frpc_background(background_tasks: BackgroundTasks):
+    background_tasks.add_task(stop_frpc)
+    background_tasks.add_task(time.sleep, 1)
+    background_tasks.add_task(start_frpc)
 
 @app.post("/create-vm")
 async def create_vm(vm: VirtualMachine, background_tasks: BackgroundTasks):
     try:
-        vm_path = f".vms/{vm.username}"
+        vm_path = VMS_DIR / vm.username
+        if vm_path.exists():
+            raise HTTPException(status_code=400, detail=f"VM '{vm.username}' already exists.")
+        if not (SSH_DIR / f"{vm.key_name}.pub").exists():
+            raise HTTPException(status_code=400, detail=f"SSH key '{vm.key_name}' does not exist. Generate it first.")
+
         private_ip = find_ip()
         registry = load_vm_registry()
         
-        registry[vm.username] = {
-            "private_ip": private_ip,
-            "key_name": vm.key_name,
-            "ram": vm.ram,
-            "cpu": vm.cpu,
-            "image": vm.image,
-            "inbound_rules": [rule.model_dump() for rule in vm.inbound_rules]
-        }
+        vm_data = vm.model_dump()
+        vm_data["private_ip"] = private_ip
+        
+        proxies_to_add = []
+        ## FIXED ## --- Logic to assign unique ports within the same request ---
+        ports_assigned_in_this_request = set()
+        for rule in vm_data["inbound_rules"]:
+            remotePort = find_available_remotePort(exclude_ports=ports_assigned_in_this_request)
+            ports_assigned_in_this_request.add(remotePort)
+            rule["remotePort"] = remotePort
+            proxy_name = f"{vm.username}-{rule['vm_port']}"
+            
+            ## FIXED ## --- Changed remotePort to remotePort ---
+            new_proxy_toml = f"""
+[[proxies]]
+name = "{proxy_name}"
+type = "tcp"
+localIP = "{private_ip}"
+localPort = {rule['vm_port']}
+remotePort = {remotePort}
+"""
+            proxies_to_add.append(new_proxy_toml)
+        
+        registry[vm.username] = vm_data
         save_vm_registry(registry)
 
-        if os.path.exists(vm_path):
-            raise HTTPException(status_code=400, detail=f"VM '{vm.username}' already exists.")
+        with open(FRP_CONFIG_PATH, "a") as f:
+            for proxy_toml in proxies_to_add:
+                f.write(proxy_toml)
+        print(f"Appended {len(proxies_to_add)} proxies for '{vm.username}' to frpc.toml")
 
-        if not os.path.exists(f".ssh/{vm.key_name}.pub"):
-            raise HTTPException(status_code=400, detail=f"SSH key '{vm.key_name}' does not exist. Generate it first.")
-
-        os.makedirs(vm_path, exist_ok=True)
-
+        vm_path.mkdir(exist_ok=True)
         vagrantfile_content = get_vagrantfile_content(vm, private_ip)
-        vagrantfile_path = os.path.join(vm_path, "Vagrantfile")
-
-        with open(vagrantfile_path, "w") as f:
+        with open(vm_path / "Vagrantfile", "w") as f:
             f.write(vagrantfile_content)
 
-        background_tasks.add_task(stream_vagrant_up, vm_path)
-        return {"message": f"VM '{vm.username}' is being provisioned. Logs are streaming in the server terminal."}
+        background_tasks.add_task(stream_vagrant_up, str(vm_path))
+        restart_frpc_background(background_tasks)
+
+        return {"message": f"VM '{vm.username}' is being provisioned. Tunnels are being configured."}
 
     except Exception as e:
+        registry = load_vm_registry()
+        if vm.username in registry:
+            del registry[vm.username]
+            save_vm_registry(registry)
         raise HTTPException(status_code=500, detail=str(e))
 
-
-
 @app.delete("/delete-vm/{username}")
-async def delete_vm(username: str):
+async def delete_vm(username: str, background_tasks: BackgroundTasks):
     try:
-        vm_path = f".vms/{username}"
-
-        if not os.path.exists(vm_path):
+        vm_path = VMS_DIR / username
+        if not vm_path.exists():
             raise HTTPException(status_code=404, detail=f"VM '{username}' does not exist.")
 
-        # Destroy the VM
-        destroy_proc = subprocess.run(
-            ["vagrant", "destroy", "-f"],
-            cwd=vm_path,
-            capture_output=True,
-            text=True
-        )
-        
+        destroy_proc = subprocess.run(["vagrant", "destroy", "-f"], cwd=vm_path, capture_output=True, text=True)
         if destroy_proc.returncode != 0:
-            raise HTTPException(status_code=500, detail=f"Vagrant destroy failed: {destroy_proc.stderr.strip()}")
+            print(f"Warning: Vagrant destroy failed for {username}, but proceeding with cleanup. Error: {destroy_proc.stderr.strip()}")
 
-        # Remove VM directory
         rmtree(vm_path)
         
-        # Remove VM from registry
         registry = load_vm_registry()
         if username in registry:
+            vm_to_delete = registry[username]
+            proxy_names_to_delete = {f"{username}-{rule['vm_port']}" for rule in vm_to_delete.get("inbound_rules", [])}
+            
+            if proxy_names_to_delete:
+                with open(FRP_CONFIG_PATH, "r") as f:
+                    content = f.read()
+                
+                # The first part is the server config, the rest are proxy blocks
+                parts = content.split("\n[[proxies]]\n")
+                server_config = parts[0]
+                proxy_blocks = parts[1:]
+
+                # Keep only the proxy blocks that we don't want to delete
+                kept_blocks = []
+                for block in proxy_blocks:
+                    # Check if this block's name is in our deletion set
+                    # We construct the full 'name = "..."' string for a precise match
+                    if not any(f'name = "{name}"' in block for name in proxy_names_to_delete):
+                        kept_blocks.append(block)
+
+                # Rebuild the file content
+                new_content = server_config
+                if kept_blocks:
+                    # Add the [[proxies]] delimiter back for each kept block
+                    new_content += "\n[[proxies]]\n" + "\n[[proxies]]\n".join(kept_blocks)
+                
+                # Write the new content back to the file
+                with open(FRP_CONFIG_PATH, "w") as f:
+                    f.write(new_content)
+                # --- End of replaced block ---
+
+                print(f"Removed proxies for '{username}' from frpc.toml")
+                restart_frpc_background(background_tasks)
+
             del registry[username]
             save_vm_registry(registry)
 
-        return {"message": f"VM '{username}' destroyed and directory removed successfully."}
-
+        return {"message": f"VM '{username}' destroyed and directory/tunnels removed successfully."}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-
-#########################################################################################################################################################################
-
-
-
-
-############################################################# Port Forwarding and Ngrok Setup ###########################################################################
-def forward_and_expose_ports(vm: VirtualMachine):
+@app.post("/start-vm/{username}")
+async def start_vm(username: str):
     try:
-        private_ip = vm.private_ip
-        
-        for rule in vm.inbound_rules:
-            ssh_cmd = [
-                "ssh",
-                "-i", f".ssh/{vm.key_name}",
-                "-o", "StrictHostKeyChecking=no",
-                "-o", "UserKnownHostsFile=/dev/null",
-                "-N",
-                "-L", f"{rule.localhost_port}:{private_ip}:{rule.vm_port}",
-                f"{vm.username}@{private_ip}"
-            ]
-            def ssh_tunnel():
-                print(f"[SSH] Forwarding localhost:{rule.localhost_port} → {private_ip}:{rule.vm_port}...")
-                subprocess.run(ssh_cmd)
-
-            threading.Thread(target=ssh_tunnel, daemon=True).start()
-            time.sleep(1)  # Give tunnel time to start
-
-            if rule.type == "http":
-                ngrok_cmd = ["ngrok", "http", str(rule.localhost_port)]
-            elif rule.type == "tcp":
-                ngrok_cmd = ["ngrok", "tcp", str(rule.localhost_port)]
-            else:
-                print(f"[WARNING] Unknown rule type: {rule.type}")
-                continue
-
-            def start_ngrok():
-                print(f"[NGROK] Exposing localhost:{rule.localhost_port} over {rule.type.upper()}...")
-                subprocess.run(ngrok_cmd)
-
-            threading.Thread(target=start_ngrok, daemon=True).start()
-            time.sleep(2)
-
+        vm_path = VMS_DIR / username
+        if not vm_path.exists():
+            raise HTTPException(status_code=404, detail=f"VM '{username}' does not exist.")
+        start_proc = subprocess.run(["vagrant", "up"], cwd=vm_path, capture_output=True, text=True)
+        if start_proc.returncode != 0:
+            raise HTTPException(status_code=500, detail=f"VM booting failed: {start_proc.stderr.strip()}")
+        return {"message": f"VM '{username}' booted successfully."}
     except Exception as e:
-        print(f"[ERROR] Error while forwarding ports: {e}")
-        
-        
-        
-        
-@app.post("/expose-vm/{username}")
-async def expose_vm(username: str, background_tasks: BackgroundTasks):
-    try:
-        registry = load_vm_registry()
-        if username not in registry:
-            raise HTTPException(status_code=404, detail="VM not found in registry.")
-
-        metadata = registry[username]
-        private_ip = metadata["private_ip"]
-        key_name = metadata["key_name"]
-
-        # Load VM's Vagrantfile to get box username (or assume `username`)
-
-        vm = VirtualMachine(
-            username=username,
-            key_name=metadata["key_name"],
-            ram=metadata['ram'], 
-            cpu=metadata['cpu'], 
-            image=metadata['image'],
-            inbound_rules=metadata["inbound_rules"],
-            private_ip=private_ip
-        )
-
-        background_tasks.add_task(forward_and_expose_ports, vm)
-
-        return {"message": f"Inbound rules are being applied for VM '{username}'."}
-
-    except Exception as e:
-        print(e)
         raise HTTPException(status_code=500, detail=str(e))
-        
 
-##########################################################################################################################################################################
-
-
-if __name__ == "__Server__":
-    import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+@app.post("/stop-vm/{username}")
+async def stop_vm(username: str):
+    try:
+        vm_path = VMS_DIR / username
+        if not vm_path.exists():
+            raise HTTPException(status_code=404, detail=f"VM '{username}' does not exist.")
+        stop_proc = subprocess.run(["vagrant", "halt"], cwd=vm_path, capture_output=True, text=True)
+        if stop_proc.returncode != 0:
+            raise HTTPException(status_code=500, detail=f"Vagrant halt failed: {stop_proc.stderr.strip()}")
+        return {"message": f"VM '{username}' Stopped successfully."}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
1. What We Wanted to Achieve Today
Our goal was to establish the core networking backbone for Nimbus-IaaS. This involved setting up a secure and reliable way to expose the VMs running on your local PC to the internet, and then building the automation layer to manage these connections programmatically.

2. How We Approached It
We implemented the "Gateway" and "Worker" components of our architecture.

We set up an AWS EC2 instance to act as our stable public gateway.

We configured the frps (server) on the EC2 instance to listen for connections.

We configured the frpc (client) on your local PC to establish the tunnels.

We then integrated the frpc management logic directly into the FastAPI server to automate the creation and deletion of tunnels whenever a VM's state changes.

3. What We Did Achieve
We successfully set up the frps server on your AWS EC2 instance and configured its security group.

We successfully set up the frpc client on your local PC and tested the tunnel connection.

We secured the connection between the client and server using an authentication token.

We wrote and debugged a complete, automated FastAPI server that can:

Manage the lifecycle of Vagrant VMs (create, delete, start, stop).

Automatically find available private IPs and public ports.

Programmatically add and remove proxy configurations from the frpc.toml file.

Automatically restart the frpc client in the background to apply changes instantly.

Handle startup and shutdown gracefully using the modern lifespan manager.

4. Errors We Encountered and Fixed
Deprecated Code: We identified and replaced the deprecated @app.on_event decorators with the modern lifespan context manager in FastAPI.

frpc Configuration Bug: We fixed a bug where the API was writing remotePort (camelCase) to the .toml file instead of the correct remote_port (snake_case), which was causing an "unmarshal" error.

Port Allocation Bug: We fixed a logic error where the API was assigning the same public remote port to multiple inbound rules for a single VM. The code now correctly allocates a unique port for each rule.